### PR TITLE
移除 _config.yml 中 Leancloud 的相关配置信息

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,8 +44,8 @@ start_time: "2018-02-10"
 # 如何开启 评论&统计 插件：https://godbmw.com/passages/2018-11-15-theme-bmw-docs-zh/
 # 请申请自己的 appid 和 appkey，并且替换下面的 appid 和 appkey
 leancloud:
-  appid: Hyq9wkH495DgNHWhDQCOfQSp-gzGzoHsz # 填写您的appid
-  appkey: WaR7nrzhliHj9aVwdQzkdlGd # 填写您的appkey
+  appid: YOUR APPID # 填写您的appid
+  appkey: YOUR APPKEY # 填写您的appkey
   comment: true # 是否开启评论系统
   count: true # 是否开启文章统计
 


### PR DESCRIPTION
移除 _config.yml 中 Leancloud 的 APPID 和 APPKEY 信息。
相关信息不应该出现在配置文件中的，而应该用支付替代。