### PR TITLE
change:(head.ejs) switch cdn source

### DIFF
--- a/layout/partials/head.ejs
+++ b/layout/partials/head.ejs
@@ -61,7 +61,7 @@
   <% } %>
 
   <% if(theme.mathjax) { %>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
+    <script type="text/javascript" src="//cdnjs.loli.net/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
   <% } %>
 
   <% if(theme.leancloud.comment) { %>
@@ -81,7 +81,7 @@
     <link rel="apple-touch-icon" href="<%- url_for(theme.favicon.touch_icon) %>">
   <% } %>
 
-  <link href="//netdna.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="//cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
 
   <%- css(['/css/index.css', '/styles/components/highlight/highlight.css']) %>
 


### PR DESCRIPTION
Switch CDN Source to cdnjs.loli.net or cdn.jsdelivr.net

切换了 MathJax 以及 Font-awesome 的加载源。

cdnjs.cloudflare.com 以及 netdna.bootstrapcdn.com 均属于海外 CDN，国内体验并不好（参见 https://www.justhx.com/matters/ ），故此切换到了 cdnjs.loli.net （cdnjs.cloudflare.com 的全量镜像）以及 cdn.jsdelivr.net（中国大陆网宿 CDN，海外 Fastly + CloudFlare + Stackpath）。