### PR TITLE
修复自定义页面无法加载的问题

### DIFF
--- a/layout/page.ejs
+++ b/layout/page.ejs
@@ -1,0 +1,11 @@
+<% if(page.type === 'tags') { %>
+  <%- partial('tags') %>
+<% } else if(page.type === 'categories') { %>
+  <%- partial('categories') %>
+<% } else if(page.type === 'about') { %>
+  <%- partial('about') %>
+<% } else if(page.type === 'friends') { %>
+  <%- partial('friends') %>
+<% } else { %>
+<%- partial('passage') %>
+<% } %>

--- a/layout/passage.ejs
+++ b/layout/passage.ejs
@@ -3,7 +3,7 @@
     <span>
       <i class="fa fa-calendar"></i><%- page.date.format("YYYY-MM-DD") %>
     </span>
-    <% if(page.categories.length > 0) { %>
+    <% if(page.categories && page.categories.length > 0) { %>
       <span>
         | <a href="<%- url_for(page.categories.data[0].path) %>"><i class="fa fa-bookmark"></i><%- page.categories.data[0].name %></a>
       </span>
@@ -44,7 +44,7 @@
       </div>
     </aside>
   <% } %>
-  <% if(page.tags.length > 0) { %>
+  <% if(page.tags && page.tags.length > 0) { %>
     <div class="passage-tags">
     <% for(let tag of page.tags.data) { %> 
       <a href="<%- url_for(tag.path) %>"><i class="fa fa-tags"></i><%- tag.name %></a>

--- a/layout/passage.ejs
+++ b/layout/passage.ejs
@@ -3,7 +3,7 @@
     <span>
       <i class="fa fa-calendar"></i><%- page.date.format("YYYY-MM-DD") %>
     </span>
-    <% if(page.categories && page.categories.length > 0) { %>
+    <% if(page.categories && page.categories.data && page.categories.length > 0) { %>
       <span>
         | <a href="<%- url_for(page.categories.data[0].path) %>"><i class="fa fa-bookmark"></i><%- page.categories.data[0].name %></a>
       </span>


### PR DESCRIPTION

修复后可以通过 
```bash
hexo new page <page-name>
```
增加 `tags`，`categories`，`about`，`friends` 外的自定义 page 页面。

主要是新增了 `page.ejs` 以及在 `passage.ejs` 中增加了对 `page.categories` 和 `page.tags` 的判断。

解决了: #30

master 分支比 develop 分支新，所以提给 master 了。